### PR TITLE
Update RLS instructions and add helper SQL

### DIFF
--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -91,3 +91,6 @@ npm run build
 - Enable realtime on tables in dashboard
 - Check subscription filters
 - Verify network connectivity
+### Session Management Issues
+If a teacher account cannot start or control a session because of row level security, run the SQL script `allow-all-teachers-manage-sessions.sql` in the Supabase SQL Editor.
+This policy lets any user with role `teacher` manage all sessions. Remember to revert the policy before production.

--- a/allow-all-teachers-manage-sessions.sql
+++ b/allow-all-teachers-manage-sessions.sql
@@ -1,0 +1,12 @@
+-- Allow all teachers to manage any session
+-- Execute this script in the Supabase SQL Editor
+
+DROP POLICY IF EXISTS "Teachers can manage their own sessions" ON sessions;
+
+CREATE POLICY "Teachers can manage any session" ON sessions
+FOR ALL USING (
+  EXISTS (
+    SELECT 1 FROM profiles p
+    WHERE p.id = auth.uid() AND p.role = 'teacher'
+  )
+);


### PR DESCRIPTION
## Summary
- add `allow-all-teachers-manage-sessions.sql` to relax the session RLS policy
- mention the new script in `SUPABASE_SETUP.md` for troubleshooting session control

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6843749fd3648330a91bd3b883778812