### PR TITLE
Replace service console logs with logger

### DIFF
--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabase';
 import type { User, AuthError } from '@supabase/supabase-js';
+import { logger } from './logger';
 
 export interface UserProfile {
   id: string;
@@ -14,7 +15,7 @@ class AuthService {
   // Sign in teacher with email/password
   async signInTeacher(email: string, password: string): Promise<User> {
     try {
-      console.log('AuthService: Starting sign in process for:', email);
+      logger.debug('AuthService: Starting sign in process for:', email);
       const { data, error } = await supabase.auth.signInWithPassword({
         email,
         password,
@@ -23,13 +24,13 @@ class AuthService {
       if (error) throw error;
       if (!data.user) throw new Error('No user returned from sign in');
 
-      console.log('AuthService: Sign in successful, updating last login...');
+      logger.debug('AuthService: Sign in successful, updating last login...');
       await this.updateLastLogin(data.user.id);
-      console.log('AuthService: Last login updated, returning user');
+      logger.debug('AuthService: Last login updated, returning user');
       
       return data.user;
     } catch (error: any) {
-      console.error('Error signing in teacher:', error);
+      logger.error('Error signing in teacher:', error);
       throw new Error(this.getAuthErrorMessage(error.message));
     }
   }
@@ -64,7 +65,7 @@ class AuthService {
 
       return data.user;
     } catch (error: any) {
-      console.error('Error registering teacher:', error);
+      logger.error('Error registering teacher:', error);
       throw new Error(this.getAuthErrorMessage(error.message));
     }
   }
@@ -76,7 +77,7 @@ class AuthService {
       const tempEmail = `${studentName.toLowerCase().replace(/\s+/g, '')}_${Date.now()}@temp.student`;
       const tempPassword = 'student123';
 
-      console.log('Creating temporary student account:', tempEmail);
+      logger.debug('Creating temporary student account:', tempEmail);
 
       const { data, error } = await supabase.auth.signUp({
         email: tempEmail,
@@ -99,7 +100,7 @@ class AuthService {
 
       return data.user;
     } catch (error: any) {
-      console.error('Error signing in student:', error);
+      logger.error('Error signing in student:', error);
       throw new Error('Failed to join session. Please try again.');
     }
   }
@@ -110,7 +111,7 @@ class AuthService {
       const { error } = await supabase.auth.signOut();
       if (error) throw error;
     } catch (error) {
-      console.error('Error signing out:', error);
+      logger.error('Error signing out:', error);
       throw new Error('Failed to sign out');
     }
   }
@@ -146,7 +147,7 @@ class AuthService {
 
       return data;
     } catch (error) {
-      console.error('Error getting user profile:', error);
+      logger.error('Error getting user profile:', error);
       return null;
     }
   }
@@ -160,7 +161,7 @@ class AuthService {
 
       if (error) throw error;
     } catch (error) {
-      console.error('Error creating user profile:', error);
+      logger.error('Error creating user profile:', error);
     }
   }
 
@@ -174,7 +175,7 @@ class AuthService {
 
       if (error) throw error;
     } catch (error: any) {
-      console.error('Error updating last login:', error);
+      logger.error('Error updating last login:', error);
     }
   }
 

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,0 +1,35 @@
+export type LogLevel = 'debug' | 'error' | 'none';
+
+class Logger {
+  private level: LogLevel;
+
+  constructor() {
+    const envLevel = (import.meta.env.VITE_LOG_LEVEL as LogLevel) || undefined;
+    if (envLevel) {
+      this.level = envLevel;
+    } else {
+      this.level = import.meta.env.DEV ? 'debug' : 'error';
+    }
+  }
+
+  private shouldLog(msgLevel: LogLevel): boolean {
+    const levels: Record<LogLevel, number> = { none: 0, error: 1, debug: 2 };
+    return levels[msgLevel] <= levels[this.level];
+  }
+
+  debug(...args: unknown[]): void {
+    if (this.shouldLog('debug')) {
+      // eslint-disable-next-line no-console
+      console.log(...args);
+    }
+  }
+
+  error(...args: unknown[]): void {
+    if (this.shouldLog('error')) {
+      // eslint-disable-next-line no-console
+      console.error(...args);
+    }
+  }
+}
+
+export const logger = new Logger();

--- a/src/services/quizService.ts
+++ b/src/services/quizService.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabase';
 import { Quiz, Question } from '../types';
+import { logger } from './logger';
 
 export interface DatabaseQuiz extends Omit<Quiz, 'createdAt' | 'updatedAt'> {
   created_at: string;
@@ -23,7 +24,7 @@ class QuizService {
   // Create a new quiz
   async createQuiz(quiz: Omit<Quiz, 'id' | 'createdAt' | 'updatedAt'>): Promise<string> {
     try {
-      console.log('Creating quiz with data:', quiz);
+      logger.debug('Creating quiz with data:', quiz);
       
       const now = new Date().toISOString();
       const quizData = {
@@ -35,7 +36,7 @@ class QuizService {
         updated_at: now,
       };
 
-      console.log('Formatted quiz data:', quizData);
+      logger.debug('Formatted quiz data:', quizData);
 
       const { data, error } = await supabase
         .from(this.table)
@@ -43,16 +44,16 @@ class QuizService {
         .select('id')
         .single();
 
-      console.log('Supabase response:', { data, error });
+      logger.debug('Supabase response:', { data, error });
 
       if (error) {
-        console.error('Supabase error details:', error);
+        logger.error('Supabase error details:', error);
         throw error;
       }
       
       return data.id;
     } catch (error) {
-      console.error('Error creating quiz:', error);
+      logger.error('Error creating quiz:', error);
       if (error instanceof Error) {
         throw new Error(`Failed to create quiz: ${error.message}`);
       }
@@ -79,7 +80,7 @@ class QuizService {
 
       if (error) throw error;
     } catch (error) {
-      console.error('Error updating quiz:', error);
+      logger.error('Error updating quiz:', error);
       throw new Error('Failed to update quiz');
     }
   }
@@ -94,7 +95,7 @@ class QuizService {
 
       if (error) throw error;
     } catch (error) {
-      console.error('Error deleting quiz:', error);
+      logger.error('Error deleting quiz:', error);
       throw new Error('Failed to delete quiz');
     }
   }
@@ -115,7 +116,7 @@ class QuizService {
 
       return this.convertDatabaseQuiz(data);
     } catch (error) {
-      console.error('Error getting quiz:', error);
+      logger.error('Error getting quiz:', error);
       throw new Error('Failed to get quiz');
     }
   }
@@ -133,7 +134,7 @@ class QuizService {
 
       return data.map(quiz => this.convertDatabaseQuiz(quiz));
     } catch (error) {
-      console.error('Error getting user quizzes:', error);
+      logger.error('Error getting user quizzes:', error);
       throw new Error('Failed to get quizzes');
     }
   }
@@ -150,7 +151,7 @@ class QuizService {
 
       return data.map(quiz => this.convertDatabaseQuiz(quiz));
     } catch (error) {
-      console.error('Error getting all quizzes:', error);
+      logger.error('Error getting all quizzes:', error);
       throw new Error('Failed to get quizzes');
     }
   }
@@ -169,13 +170,13 @@ class QuizService {
         },
         () => {
           // Fetch updated data when changes occur
-          this.getUserQuizzes(userId).then(callback).catch(console.error);
+          this.getUserQuizzes(userId).then(callback).catch(err => logger.error(err));
         }
       )
       .subscribe();
 
     // Initial fetch
-    this.getUserQuizzes(userId).then(callback).catch(console.error);
+    this.getUserQuizzes(userId).then(callback).catch(err => logger.error(err));
 
     return () => {
       supabase.removeChannel(channel);
@@ -195,13 +196,13 @@ class QuizService {
         },
         () => {
           // Fetch updated data when changes occur
-          this.getAllQuizzes().then(callback).catch(console.error);
+          this.getAllQuizzes().then(callback).catch(err => logger.error(err));
         }
       )
       .subscribe();
 
     // Initial fetch
-    this.getAllQuizzes().then(callback).catch(console.error);
+    this.getAllQuizzes().then(callback).catch(err => logger.error(err));
 
     return () => {
       supabase.removeChannel(channel);
@@ -229,7 +230,7 @@ class QuizService {
 
       return await this.createQuiz(duplicatedQuiz);
     } catch (error) {
-      console.error('Error duplicating quiz:', error);
+      logger.error('Error duplicating quiz:', error);
       throw new Error('Failed to duplicate quiz');
     }
   }
@@ -309,7 +310,7 @@ class QuizService {
         questionTypes,
       };
     } catch (error) {
-      console.error('Error getting quiz stats:', error);
+      logger.error('Error getting quiz stats:', error);
       throw new Error('Failed to get quiz statistics');
     }
   }

--- a/src/services/sessionService.ts
+++ b/src/services/sessionService.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabase';
 import { QuizSession, Participant, QuestionResponse } from '../types';
+import { logger } from './logger';
 
 export interface DatabaseSession extends Omit<QuizSession, 'startTime' | 'endTime' | 'participants'> {
   start_time?: string;
@@ -126,7 +127,7 @@ class SessionService {
       if (error) throw error;
       return data.id;
     } catch (error) {
-      console.error('Error creating session:', error);
+      logger.error('Error creating session:', error);
       throw new Error('Failed to create session');
     }
   }
@@ -150,7 +151,7 @@ class SessionService {
 
       if (error) throw error;
     } catch (error) {
-      console.error('Error updating session:', error);
+      logger.error('Error updating session:', error);
       throw new Error('Failed to update session');
     }
   }
@@ -171,7 +172,7 @@ class SessionService {
 
       return this.convertDatabaseSession(data);
     } catch (error) {
-      console.error('Error getting session:', error);
+      logger.error('Error getting session:', error);
       throw new Error('Failed to get session');
     }
   }
@@ -179,7 +180,7 @@ class SessionService {
   // Get session by code
   async getSessionByCode(code: string): Promise<QuizSession | null> {
     try {
-      console.log('Searching for session with code:', code.toUpperCase());
+      logger.debug('Searching for session with code:', code.toUpperCase());
       
       const { data, error } = await supabase
         .from(this.sessionsTable)
@@ -187,21 +188,21 @@ class SessionService {
         .eq('code', code.toUpperCase())
         .single();
 
-      console.log('Session search result:', { data, error });
+      logger.debug('Session search result:', { data, error });
 
       if (error) {
         if (error.code === 'PGRST116') {
-          console.log('Session not found');
+          logger.debug('Session not found');
           return null; // Row not found
         }
         throw error;
       }
 
       const session = this.convertDatabaseSession(data);
-      console.log('Converted session:', session);
+      logger.debug('Converted session:', session);
       return session;
     } catch (error) {
-      console.error('Error getting session by code:', error);
+      logger.error('Error getting session by code:', error);
       throw new Error('Failed to find session');
     }
   }
@@ -219,7 +220,7 @@ class SessionService {
 
       return data.map(session => this.convertDatabaseSession(session));
     } catch (error) {
-      console.error('Error getting teacher sessions:', error);
+      logger.error('Error getting teacher sessions:', error);
       throw new Error('Failed to get sessions');
     }
   }
@@ -227,7 +228,7 @@ class SessionService {
   // Add participant to session
   async addParticipant(sessionId: string, participant: Omit<Participant, 'id' | 'joinedAt'>): Promise<string> {
     try {
-      console.log('Adding participant:', { sessionId, participant });
+      logger.debug('Adding participant:', { sessionId, participant });
       
       const participantData = {
         name: participant.name,
@@ -238,7 +239,7 @@ class SessionService {
         joined_at: new Date().toISOString(),
       };
 
-      console.log('Participant data to insert:', participantData);
+      logger.debug('Participant data to insert:', participantData);
 
       const { data, error } = await supabase
         .from(this.participantsTable)
@@ -246,7 +247,7 @@ class SessionService {
         .select('id')
         .single();
 
-      console.log('Add participant result:', { data, error });
+      logger.debug('Add participant result:', { data, error });
 
       if (error) throw error;
       
@@ -255,7 +256,7 @@ class SessionService {
       
       return data.id;
     } catch (error) {
-      console.error('Error adding participant:', error);
+      logger.error('Error adding participant:', error);
       throw new Error('Failed to join session');
     }
   }
@@ -276,7 +277,7 @@ class SessionService {
 
       if (error) throw error;
     } catch (error) {
-      console.error('Error updating participant:', error);
+      logger.error('Error updating participant:', error);
       throw new Error('Failed to update participant');
     }
   }
@@ -294,7 +295,7 @@ class SessionService {
 
       return data.map(participant => this.convertDatabaseParticipant(participant));
     } catch (error) {
-      console.error('Error getting participants:', error);
+      logger.error('Error getting participants:', error);
       throw new Error('Failed to get participants');
     }
   }
@@ -332,7 +333,7 @@ class SessionService {
       if (error) throw error;
       return data.id;
     } catch (error) {
-      console.error('Error submitting response:', error);
+      logger.error('Error submitting response:', error);
       throw new Error('Failed to submit response');
     }
   }
@@ -351,7 +352,7 @@ class SessionService {
 
       return data.map(response => this.convertDatabaseResponse(response));
     } catch (error) {
-      console.error('Error getting responses:', error);
+      logger.error('Error getting responses:', error);
       throw new Error('Failed to get responses');
     }
   }
@@ -369,7 +370,7 @@ class SessionService {
 
       return data.map(response => this.convertDatabaseResponse(response));
     } catch (error) {
-      console.error('Error getting session responses:', error);
+      logger.error('Error getting session responses:', error);
       throw new Error('Failed to get responses');
     }
   }
@@ -476,7 +477,7 @@ class SessionService {
         .eq('session_id', sessionId);
 
     } catch (error) {
-      console.error('Error ending session:', error);
+      logger.error('Error ending session:', error);
       throw new Error('Failed to end session');
     }
   }
@@ -503,7 +504,7 @@ class SessionService {
         .eq('id', sessionId);
 
     } catch (error) {
-      console.error('Error deleting session:', error);
+      logger.error('Error deleting session:', error);
       throw new Error('Failed to delete session');
     }
   }
@@ -520,7 +521,7 @@ class SessionService {
         })
         .eq('id', sessionId);
     } catch (error) {
-      console.error('Error updating participant count:', error);
+      logger.error('Error updating participant count:', error);
     }
   }
 
@@ -553,7 +554,7 @@ class SessionService {
         averageResponseTime: Math.round(averageResponseTime),
       };
     } catch (error) {
-      console.error('Error getting session stats:', error);
+      logger.error('Error getting session stats:', error);
       throw new Error('Failed to get session statistics');
     }
   }


### PR DESCRIPTION
## Summary
- create a simple logger with configurable log level
- replace console logging in auth, quiz and session services

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68443ec1ff388330867fa083a794faac