### PR TITLE
Add Supabase row types and typing fixes

### DIFF
--- a/src/services/quizService.ts
+++ b/src/services/quizService.ts
@@ -1,17 +1,11 @@
 import { supabase } from './supabase';
-import { Quiz, Question } from '../types';
-
-export interface DatabaseQuiz extends Omit<Quiz, 'createdAt' | 'updatedAt'> {
-  created_at: string;
-  updated_at: string;
-  created_by: string;
-}
+import { Quiz, DatabaseQuiz } from '../types';
 
 class QuizService {
   private readonly table = 'quizzes';
 
   // Convert database quiz to application format
-  private convertDatabaseQuiz(dbQuiz: any): Quiz {
+  private convertDatabaseQuiz(dbQuiz: DatabaseQuiz): Quiz {
     return {
       ...dbQuiz,
       createdAt: new Date(dbQuiz.created_at),
@@ -63,7 +57,7 @@ class QuizService {
   // Update an existing quiz
   async updateQuiz(quizId: string, updates: Partial<Omit<Quiz, 'id' | 'createdAt' | 'updatedAt'>>): Promise<void> {
     try {
-      const updateData: any = {
+      const updateData: Partial<DatabaseQuiz> = {
         updated_at: new Date().toISOString(),
       };
 

--- a/src/services/sessionService.ts
+++ b/src/services/sessionService.ts
@@ -1,30 +1,12 @@
 import { supabase } from './supabase';
-import { QuizSession, Participant, QuestionResponse } from '../types';
-
-export interface DatabaseSession extends Omit<QuizSession, 'startTime' | 'endTime' | 'participants'> {
-  start_time?: string;
-  end_time?: string;
-  created_at: string;
-  updated_at: string;
-  created_by: string;
-  quiz_id: string;
-  current_question_index: number;
-}
-
-export interface DatabaseParticipant extends Omit<Participant, 'joinedAt' | 'sessionId'> {
-  joined_at: string;
-  session_id: string;
-  current_question_index: number;
-}
-
-export interface DatabaseResponse extends Omit<QuestionResponse, 'submittedAt' | 'participantId' | 'questionId'> {
-  submitted_at: string;
-  participant_id: string;
-  question_id: string;
-  session_id: string;
-  time_spent: number;
-  is_correct: boolean;
-}
+import {
+  QuizSession,
+  Participant,
+  QuestionResponse,
+  DatabaseSession,
+  DatabaseParticipant,
+  DatabaseResponse,
+} from '../types';
 
 class SessionService {
   private readonly sessionsTable = 'sessions';
@@ -62,7 +44,7 @@ class SessionService {
   }
 
   // Convert database objects to application format
-  private convertDatabaseSession(data: any): QuizSession {
+  private convertDatabaseSession(data: DatabaseSession): QuizSession {
     return {
       id: data.id,
       quizId: data.quiz_id,
@@ -76,7 +58,7 @@ class SessionService {
     };
   }
 
-  private convertDatabaseParticipant(data: any): Participant {
+  private convertDatabaseParticipant(data: DatabaseParticipant): Participant {
     return {
       id: data.id,
       name: data.name,
@@ -88,7 +70,7 @@ class SessionService {
     };
   }
 
-  private convertDatabaseResponse(data: any): QuestionResponse {
+  private convertDatabaseResponse(data: DatabaseResponse): QuestionResponse {
     return {
       id: data.id,
       participantId: data.participant_id,
@@ -134,7 +116,7 @@ class SessionService {
   // Update session status and properties
   async updateSession(sessionId: string, updates: Partial<QuizSession>): Promise<void> {
     try {
-      const updateData: any = {
+      const updateData: Partial<DatabaseSession> = {
         updated_at: new Date().toISOString(),
       };
 
@@ -263,7 +245,7 @@ class SessionService {
   // Update participant status
   async updateParticipant(participantId: string, updates: Partial<Participant>): Promise<void> {
     try {
-      const updateData: any = {};
+      const updateData: Partial<DatabaseParticipant> = {};
       
       if (updates.status) updateData.status = updates.status;
       if (updates.currentQuestionIndex !== undefined) updateData.current_question_index = updates.currentQuestionIndex;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,3 +65,49 @@ export interface MatchColumn {
   right: string[];
   correctMatches: { [key: string]: string };
 }
+
+// Raw database row types returned by Supabase
+export interface DatabaseQuiz {
+  id: string;
+  title: string;
+  description: string;
+  questions: Question[];
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+}
+
+export interface DatabaseSession {
+  id: string;
+  quiz_id: string;
+  code: string;
+  status: 'waiting' | 'active' | 'paused' | 'completed';
+  current_question_index: number;
+  start_time?: string;
+  end_time?: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DatabaseParticipant {
+  id: string;
+  name: string;
+  session_id: string;
+  joined_at: string;
+  status: 'connected' | 'disconnected';
+  current_question_index: number;
+  score: number;
+}
+
+export interface DatabaseResponse {
+  id: string;
+  participant_id: string;
+  question_id: string;
+  session_id: string;
+  answer: string | string[];
+  is_correct: boolean;
+  points: number;
+  time_spent: number;
+  submitted_at: string;
+}


### PR DESCRIPTION
## Summary
- define raw Supabase row interfaces
- use the new types in `quizService` and `sessionService`
- remove `any` usage from conversion helpers

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error and other lint issues)*
- `npm run build` *(fails to compile due to existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68443ec2b30083308b451129f277f02d