### PR TITLE
Add service unit tests

### DIFF
--- a/src/services/__tests__/quizService.test.ts
+++ b/src/services/__tests__/quizService.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { quizService } from '../quizService';
+import { supabase } from '../supabase';
+
+vi.mock('../supabase', () => ({
+  supabase: {
+    from: vi.fn()
+  }
+}));
+
+const fromMock = supabase.from as unknown as vi.Mock;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('quizService', () => {
+  it('creates a quiz', async () => {
+    const singleMock = vi.fn().mockResolvedValue({ data: { id: 'quiz123' }, error: null });
+    const selectMock = vi.fn().mockReturnValue({ single: singleMock });
+    const insertMock = vi.fn().mockReturnValue({ select: selectMock });
+    fromMock.mockReturnValueOnce({ insert: insertMock });
+
+    const quiz = { title: 'Test', description: 'Desc', questions: [], createdBy: 'user1' };
+    const id = await quizService.createQuiz(quiz);
+
+    expect(id).toBe('quiz123');
+    expect(fromMock).toHaveBeenCalledWith('quizzes');
+    expect(insertMock).toHaveBeenCalledWith([
+      expect.objectContaining({ title: 'Test', description: 'Desc', created_by: 'user1' })
+    ]);
+    expect(selectMock).toHaveBeenCalledWith('id');
+    expect(singleMock).toHaveBeenCalled();
+  });
+
+  it('updates a quiz', async () => {
+    const eqMock = vi.fn().mockResolvedValue({ error: null });
+    const updateMock = vi.fn().mockReturnValue({ eq: eqMock });
+    fromMock.mockReturnValueOnce({ update: updateMock });
+
+    await quizService.updateQuiz('id1', { title: 'New' });
+
+    expect(fromMock).toHaveBeenCalledWith('quizzes');
+    expect(updateMock.mock.calls[0][0]).toEqual(expect.objectContaining({ title: 'New' }));
+    expect(eqMock).toHaveBeenCalledWith('id', 'id1');
+  });
+});

--- a/src/services/__tests__/sessionService.test.ts
+++ b/src/services/__tests__/sessionService.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sessionService } from '../sessionService';
+import { supabase } from '../supabase';
+
+vi.mock('../supabase', () => ({
+  supabase: {
+    from: vi.fn()
+  }
+}));
+
+const fromMock = supabase.from as unknown as vi.Mock;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sessionService', () => {
+  it('creates a session', async () => {
+    const singleMock = vi.fn().mockResolvedValue({ data: { id: 'sess1' }, error: null });
+    const selectMock = vi.fn().mockReturnValue({ single: singleMock });
+    const insertMock = vi.fn().mockReturnValue({ select: selectMock });
+    fromMock.mockReturnValueOnce({ insert: insertMock });
+
+    vi.spyOn(sessionService as any, 'generateUniqueCode').mockResolvedValue('ABC123');
+
+    const id = await sessionService.createSession('quiz1', 'teacher1');
+
+    expect(id).toBe('sess1');
+    expect(fromMock).toHaveBeenCalledWith('sessions');
+    expect(insertMock.mock.calls[0][0][0]).toEqual(expect.objectContaining({ quiz_id: 'quiz1', code: 'ABC123', created_by: 'teacher1' }));
+  });
+
+  it('adds a participant', async () => {
+    const singleMock = vi.fn().mockResolvedValue({ data: { id: 'part1' }, error: null });
+    const selectMock = vi.fn().mockReturnValue({ single: singleMock });
+    const insertMock = vi.fn().mockReturnValue({ select: selectMock });
+    fromMock.mockReturnValueOnce({ insert: insertMock });
+
+    vi.spyOn(sessionService as any, 'updateSessionParticipantCount').mockResolvedValue(undefined);
+
+    const participant = { name: 'John', status: 'connected', currentQuestionIndex: 0, score: 0, sessionId: 'sess1', id: '' };
+    const id = await sessionService.addParticipant('sess1', participant);
+
+    expect(id).toBe('part1');
+    expect(fromMock).toHaveBeenCalledWith('participants');
+    expect(insertMock.mock.calls[0][0][0]).toEqual(expect.objectContaining({ name: 'John', session_id: 'sess1' }));
+  });
+});


### PR DESCRIPTION
## Summary
- add quizService tests for creating and updating a quiz
- add sessionService tests for creating sessions and adding participants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68443ec470c48330bfce179960e26832